### PR TITLE
Use --legacy-peer-deps in GitHub Pages workflow install step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --legacy-peer-deps
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
### Motivation
- `npm ci` in the GitHub Pages workflow failed due to peer dependency conflicts (npm `E403`) when installing dev deps like `typescript-eslint`, so the installer needs to ignore peer deps to complete on Actions.

### Description
- Updated `.github/workflows/deploy.yml` to run `npm ci --legacy-peer-deps` instead of `npm ci` to allow dependency installation to proceed in the Pages build job.

### Testing
- No automated tests were run because this is a workflow-only configuration change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697345cc95e8832c9253005fcab3f201)