### PR TITLE
Fix TypeScript build errors blocking GitHub Pages deploy

### DIFF
--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -324,10 +324,7 @@ export async function generatePagedPdf(
         .get('pdf')
         .then((pdf: JsPDF) => {
           addPageNumbers(pdf);
-          return pdf;
-        })
-        .save()
-        .then(() => {
+          pdf.save(PDF_CONFIG.PAGED_FILENAME);
           resolve();
         })
         .catch((err: Error) => {


### PR DESCRIPTION
### Motivation
- CI publishing to GitHub Pages was failing due to TypeScript build errors originating from PDF generation and sanitization modules.
- The goal is to remove implicit-any and promise/typing issues so the project can type-check and the action can complete the build step.

### Description
- Adjusted paged PDF generation in `src/pdf.ts` to call `pdf.save(...)` after adding page numbers and resolve the surrounding promise immediately to avoid the previous html2pdf promise-chain typing issues.
- Tightened DOMPurify typings in `src/sanitize.ts` by importing `Config` and `HookEvent` types and adding explicit parameter types for hooks and intermediate variables to eliminate implicit `any` errors.
- Reformatted the sanitize hook body for clearer scoping and ensured the style-filtering logic remains unchanged while being fully typed.

### Testing
- Ran `npm run typecheck`; implicit `any` errors in hooks were resolved but type-check still reports missing module/type declarations for `dompurify` and `marked` in this environment because `node_modules` are not installed, so the remaining errors are environmental rather than code-type issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6973471fb708832ca58be232ca2ca796)