### PR TITLE
Fix DOMPurify hook typing for build

### DIFF
--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -3,7 +3,12 @@
  * 使用 DOMPurify 防止 XSS 攻击，同时允许安全的 HTML 样式
  */
 
-import DOMPurify, { type Config, type HookEvent } from 'dompurify';
+import DOMPurify, { type Config } from 'dompurify';
+
+type HookEvent = {
+  attrName: string;
+  attrValue: string | null;
+};
 
 // =============================================================================
 // DOMPurify 配置


### PR DESCRIPTION
### Motivation
- The DOMPurify `HookEvent` type import is not available/compatible with the project's TypeScript setup, causing type errors during build, so a minimal local hook event type was introduced and the import reduced to `Config` to restore compatibility.

### Description
- Replace `import DOMPurify, { type Config, type HookEvent } from 'dompurify'` with `import DOMPurify, { type Config } from 'dompurify'` and add a local `HookEvent` type (`attrName: string; attrValue: string | null;`) in `src/sanitize.ts` to satisfy the hook callback typing.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69735c7fad68832c930f71ca01eccb5e)